### PR TITLE
Use correct shared library name on FreeBSD

### DIFF
--- a/Source/SharpFont/FT.Internal.cs
+++ b/Source/SharpFont/FT.Internal.cs
@@ -70,7 +70,7 @@ namespace SharpFont
 					return IntPtr.Zero;
 				}
 
-				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+				if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
 				{
 					return NativeLibrary.Load("libfreetype.so.6", typeof(FT).Assembly, path);
 				}


### PR DESCRIPTION
This is needed for the correct shared library name to be used on FreeBSD.

A version bump/publish and dependency chase in RobustToolbox is requested to pick up this change.